### PR TITLE
Bump app version to fix auth failure

### DIFF
--- a/src/ComfortCloudClient.ts
+++ b/src/ComfortCloudClient.ts
@@ -15,7 +15,7 @@ export class ComfortCloudClient {
   readonly urlPartGroup = '/device/group/'
   readonly urlPartDevice = '/deviceStatus/'
   readonly urlPartDeviceControl = '/deviceStatus/control'
-  readonly defaultAppVersion = '1.19.1'
+  readonly defaultAppVersion = '1.20.0'
 
   private axiosInstance: AxiosInstance
 


### PR DESCRIPTION
Checking using a proxy, Panasonic require the X-APP version to be higher than 1.19.1, so I'm bumping it to 1.20.0. This gets a HTTP 200 OK response with tokens etc. I haven't been able to run the full npm test suite, as I'm getting a load of errors related to jest, but believe these are unrelated.

This should address https://github.com/marc2016/panasonic-comfort-cloud-client/issues/14