### PR TITLE
Add login support for refresh token

### DIFF
--- a/src/ComfortCloudClient.ts
+++ b/src/ComfortCloudClient.ts
@@ -47,9 +47,19 @@ export class ComfortCloudClient {
   async login(
     username: string,
     password: string,
-    language?: number
+    refreshToken?: string
   ): Promise<string> {
     try {
+      if(refreshToken) {
+        const token = await this.oauthClient.refreshToken(refreshToken)
+        if(token) {
+          const clientId = await this.getClientId(token)
+          this.clientId = clientId
+
+          return ''
+        }
+      }
+
       const token = await this.oauthClient.oAuthProcess(username, password)
       const clientId = await this.getClientId(token)
       this.clientId = clientId

--- a/src/OAuthClient.ts
+++ b/src/OAuthClient.ts
@@ -183,13 +183,13 @@ export class OAuthClient {
     return [token, tokenRefresh]
   }
 
-  public async refreshToken() {
+  public async refreshToken(tokenRefresh: string = this.tokenRefresh): Promise<string | null> {
     const response = await this.oauthClient.post(
       '/oauth/token',
       {
         'scope': 'openid offline_access comfortcloud.control a2w.control',
         'client_id': this.CLIENT_ID,
-        'refresh_token': this.tokenRefresh,
+        'refresh_token': tokenRefresh,
         'grant_type': 'refresh_token',
       },
       {
@@ -200,11 +200,17 @@ export class OAuthClient {
         },
       }
     )
+
+    if(response.status != 200)
+      return null
+
     this.token = response.data.access_token
     this.tokenRefresh = response.data.refresh_token
 
     if(this.enableAutoRefresh)
       setTimeout(this.refreshToken.bind(this), 86300000)
+
+    return this.token
   }
 
   private async loginRedirect(location: string): Promise<string|null> {

--- a/test/ComfortCloudClient.test.ts
+++ b/test/ComfortCloudClient.test.ts
@@ -10,7 +10,21 @@ const client = new ComfortCloudClient()
 
 test('login', async () => {
   await client.login(username, password)
-})
+}, 20000)
+
+test('refreshToken', async () => {
+  const clientLogin = new ComfortCloudClient()
+  await clientLogin.login(username, password)
+  
+  expect(clientLogin.oauthClient.token).not.toBeNull()
+  expect(clientLogin.oauthClient.tokenRefresh).not.toBeNull()
+
+  const clientRefreshToken = new ComfortCloudClient()
+  await clientRefreshToken.login('', '', clientLogin.oauthClient.tokenRefresh)
+
+  expect(clientRefreshToken.oauthClient.token).not.toBeNull()
+  expect(clientRefreshToken.oauthClient.tokenRefresh).not.toBeNull()
+}, 20000)
 
 test('getGroups', async () => {
   await client.login(username, password)
@@ -23,7 +37,7 @@ test('getGroups', async () => {
       expect(firstDevice instanceof Device).toBeTruthy
     }
   }
-})
+}, 20000)
 
 test('getDevice', async () => {
   await client.login(username, password)


### PR DESCRIPTION
Adding the possibility to login using the refresh token to avoid flooding Panasonic CC. The intention is to optimize login routines that needs to reinstance the client all the time, like [node-red-contrib-panasonic-comfort-cloud](https://github.com/bisand/node-red-contrib-panasonic-comfort-cloud/blob/a472e535e108e2f32767fd8e1baf8d1130d62819/src/comfort-cloud-groups.js#L16) 