### PR TITLE
Attempt to filter out other Panasonic devices (e.g. air-water heat pu…

### DIFF
--- a/src/ComfortCloudClient.ts
+++ b/src/ComfortCloudClient.ts
@@ -103,11 +103,12 @@ export class ComfortCloudClient {
         const groupsResponse = response.data.groupList
         const groups = _.map(groupsResponse, (element) => {
           const devices = _.map(element.deviceList, (device) => {
-            const retDevice = device.parameters as Device
-            retDevice.guid = device.deviceGuid
-            retDevice.name = device.deviceName
+            if (!device || !device.parameters) return null;
+            const retDevice = device.parameters;
+            retDevice.guid = device.deviceGuid || null;
+            retDevice.name = device.deviceName || null;
             return retDevice
-          })
+          }).filter(d => d); // filter nulls
           return new Group(element.groupId, element.groupName, devices)
         })
         return groups


### PR DESCRIPTION
Attempt to filter out other Panasonic devices (e.g. air-water heat pumps) not compatible with this package.

Experienced by [this user](https://community.homey.app/t/app-pro-panasonic-comfort-cloud-alternative/75906/228?u=robert_schmidt).  

They have 2 supported pumps and 1 air-to-water pump.  My app doesn't work for them because an exception is thrown - this patch should fix it.

